### PR TITLE
Fix php strict warning

### DIFF
--- a/src/CssChecker.php
+++ b/src/CssChecker.php
@@ -168,8 +168,8 @@ class CssChecker {
                 }
             }
 
-            $fileName = array_pop(explode('/', $cssFileName));
-
+            $fileNameParts = explode('/', $cssFileName)
+            $fileName = array_pop($fileNameParts);
 
             $files[] = array(
                 'name' => $fileName,


### PR DESCRIPTION
PHP Strict standards:  Only variables should be passed by reference in /data/jenkins/jobs/RG_CssChecker/workspace/webroot/vendor/timeinfeldt/csschecker/src/CssChecker.php on line 171
